### PR TITLE
도메인(테이블) 설계 내용 코드에 반영 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 //    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-test
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.6.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     // https://mvnrepository.com/artifact/javax.validation/validation-api
     //implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-validation

--- a/src/main/java/com/example/club_project/controller/AuthController.java
+++ b/src/main/java/com/example/club_project/controller/AuthController.java
@@ -3,7 +3,6 @@ package com.example.club_project.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/example/club_project/controller/AuthController.java
+++ b/src/main/java/com/example/club_project/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.club_project.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/example/club_project/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/club_project/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ package com.example.club_project.exception;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -35,14 +34,6 @@ public class GlobalExceptionHandler {
                 .errors(errors)
                 .build();
         return new ResponseEntity<>(dto, HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler({AccessDeniedException.class})
-    public ResponseEntity<?> accessDeniedHandler(IllegalArgumentException e) {
-        log.error("accessDeniedHandler: {}", e.getMessage());
-        e.printStackTrace();
-        ErrorRespDTO dto = errorToDTO(e);
-        return new ResponseEntity<>(dto, HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler({IllegalArgumentException.class})

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,15 @@
 spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MYSQL;
+    username: sa
+    password:
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,8 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+    hibernate:
+      ddl-auto: validate
   h2:
     console:
       enabled: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO users(id,email,password,name,nickname,university,introduction) VALUES (null,'test@gmail.com','1q2w3e','테스트','테스트닉네임','서울사이버대학교','안녕하세요');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,118 @@
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS categories CASCADE;
+DROP TABLE IF EXISTS clubs CASCADE;
+DROP TABLE IF EXISTS club_join_states CASCADE;
+DROP TABLE IF EXISTS posts CASCADE;
+DROP TABLE IF EXISTS pictures CASCADE;
+DROP TABLE IF EXISTS comments CASCADE;
+
+
+CREATE TABLE users
+(
+    id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    email               varchar(50)     NOT NULL COMMENT '사용자 이메일',
+    password            varchar(80)     NOT NULL COMMENT '비밀번호',
+    name                varchar(10)     NOT NULL COMMENT '이름',
+    nickname            varchar(20)     NOT NULL COMMENT '닉네임',
+    university          varchar(20)     NOT NULL COMMENT '대학교명',
+    profile_url         varchar(500)    DEFAULT NULL COMMENT '프로필 사진',
+    introduction        varchar(100)    NOT NULL COMMENT '자기소개',
+    created_at          datetime        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at          datetime        DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (id),
+    KEY users_idx_nickname (nickname)
+);
+
+
+CREATE TABLE categories
+(
+    id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    name                varchar(20)     NOT NULL COMMENT '카테고리명',
+    description         varchar(50)     NOT NULL COMMENT '카테고리 설명',
+    PRIMARY KEY (id)
+);
+
+
+CREATE TABLE clubs
+(
+    id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    name                varchar(10)     NOT NULL COMMENT '동아리명',
+    image_url           varchar(500)    DEFAULT NULL COMMENT '동아리 사진',
+    address             varchar(50)     NOT NULL COMMENT '동아리 위치',
+    university          varchar(20)     NOT NULL COMMENT '소속 대학교',
+    description         varchar(100)    NOT NULL COMMENT '동아리 소개',
+    created_at          datetime        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at          datetime        DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    category_id         bigint          DEFAULT NULL COMMENT '카테고리 id',
+    PRIMARY KEY (id),
+    KEY clubs_idx_name (name),
+    KEY clubs_idx_university (university),
+    CONSTRAINT fk_club_to_category FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+
+CREATE TABLE club_join_states
+(
+    id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    join_state          varchar(10)     NOT NULL COMMENT '가입 상태(관리자, 운영진, 일반 회원, 미가입)',
+    is_used             boolean         NOT NULL DEFAULT 0 COMMENT '동아리 탈퇴 여부 판단',
+    created_at          datetime        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    user_id             bigint          DEFAULT NULL COMMENT '사용자 id',
+    club_id             bigint          DEFAULT NULL COMMENT '동아리 id',
+    PRIMARY KEY (id),
+    KEY join_states_idx_user (user_id),
+    KEY join_states_idx_club (club_id),
+    KEY join_states_idx_user_join_state (user_id, join_state),
+    KEY join_states_idx_club_join_state (club_id, join_state),
+    CONSTRAINT fk_join_state_to_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT fk_join_state_to_club FOREIGN KEY (club_id) REFERENCES clubs (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+
+CREATE TABLE pictures
+(
+    id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    url                 varchar(500)    NOT NULL COMMENT '사진 URL',
+    description         varchar(100)    DEFAULT NULL COMMENT '사진 설명',
+    created_at          datetime        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at          datetime        DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    user_id             bigint          DEFAULT NULL COMMENT '사용자 id',
+    club_id             bigint          DEFAULT NULL COMMENT '동아리 id',
+    PRIMARY KEY (id),
+    KEY pictures_idx_user (user_id),
+    KEY pictures_idx_club (club_id),
+    CONSTRAINT fk_pictures_to_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT fk_pictures_to_club FOREIGN KEY (club_id) REFERENCES clubs (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+
+CREATE TABLE posts
+(
+    id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    content             varchar(500)    NOT NULL COMMENT '게시물 내용',
+    created_at          datetime        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at          datetime        DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    user_id             bigint          DEFAULT NULL COMMENT '사용자 id',
+    club_id             bigint          DEFAULT NULL COMMENT '동아리 id',
+    PRIMARY KEY (id),
+    KEY posts_idx_user (user_id),
+    KEY posts_idx_club (club_id),
+    CONSTRAINT fk_posts_to_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT fk_posts_to_club FOREIGN KEY (club_id) REFERENCES clubs (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+
+CREATE TABLE comments
+(
+    id                  bigint          NOT NULL AUTO_INCREMENT COMMENT 'id',
+    content             varchar(500)    NOT NULL COMMENT '댓글 내용',
+    created_at          datetime        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at          datetime        DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    post_id             bigint          DEFAULT NULL COMMENT '게시물 id',
+    user_id             bigint          DEFAULT NULL COMMENT '사용자 id',
+    PRIMARY KEY (id),
+    KEY comments_idx_post (post_id),
+    KEY comments_idx_user (user_id),
+    CONSTRAINT fk_comments_to_post FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_comments_to_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);


### PR DESCRIPTION
## 작업 목적

- JPA Entity 생성 시 auto-ddl 대신 정의한 테이블 기반으로 Entity가 생성되도록하기 위함 

## 작업 내용

- 스프링 시큐리티 의존성 제거 
- h2 의존성 추가
- schema.sql, data.sql 파일 추가

---

- 참고
  - [도메인(테이블) 설계 내용](https://www.erdcloud.com/d/SMTDkwEnvPvRSEBD4)