### PR TITLE
Category, Club ServiceLayer 유효성 체크 변경

### DIFF
--- a/src/main/java/com/example/club_project/service/category/CategoryServiceImpl.java
+++ b/src/main/java/com/example/club_project/service/category/CategoryServiceImpl.java
@@ -5,12 +5,15 @@ import com.example.club_project.domain.Category;
 import com.example.club_project.exception.custom.NotFoundException;
 import com.example.club_project.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Transactional(readOnly = true)
 @Service
@@ -60,8 +63,8 @@ public class CategoryServiceImpl implements CategoryService {
     @Override
     @Transactional
     public Category register(String name, String description) {
-        Objects.requireNonNull(name, "name 입력값은 필수입니다.");
-        Objects.requireNonNull(description, "description 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(description), "description 입력값은 필수입니다.");
 
         return categoryRepository.save(createCategory(name, description));
     }
@@ -75,7 +78,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public Category getCategory(Long id) {
-        Objects.requireNonNull(id, "id 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(id), "id 입력값은 필수입니다.");
 
         return categoryRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 id 입니다."));
@@ -83,7 +86,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public Category getCategory(String name) {
-        Objects.requireNonNull(name, "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
 
         return categoryRepository.findByName(name)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 카테고리이름입니다."));
@@ -96,20 +99,24 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public List<Category> getCategoriesById(List<Long> categories) {
-        Objects.requireNonNull(categories, "categories 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(categories), "categories 입력값은 필수입니다.");
+
         return categoryRepository.findAllById(categories);
     }
 
     @Override
     public List<Category> getCategoriesByName(List<String> categoryNames) {
-        Objects.requireNonNull(categoryNames, "categoryNames 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(categoryNames), "categoryNames 입력값은 필수입니다.");
+
         return categoryRepository.findAllNames(categoryNames);
     }
 
     @Override
     @Transactional
     public Category update(Long id, String name, String description) {
-        Objects.requireNonNull(id, "id 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(id), "id 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(description), "description 입력값은 필수입니다.");
 
         Category updatedCategory = categoryRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("수정하려는 id값이 존재하지 않습니다."));
@@ -122,7 +129,8 @@ public class CategoryServiceImpl implements CategoryService {
     @Override
     @Transactional
     public void delete(Long id) {
-        Objects.requireNonNull(id, "id 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(id), "id 입력값은 필수입니다.");
+
         Category deleteCategory = categoryRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("삭제하려는 id값이 존재하지 않습니다."));
 

--- a/src/main/java/com/example/club_project/service/club/ClubServiceImpl.java
+++ b/src/main/java/com/example/club_project/service/club/ClubServiceImpl.java
@@ -15,9 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 
 @Transactional(readOnly = true)
@@ -35,17 +34,18 @@ public class ClubServiceImpl implements ClubService {
     @Override
     @Transactional
     public ClubDTO.Response registerClub(String name, String address, String university, String description, Long categoryId) {
-        return convertToDTO(this.register(name, address, university, description, categoryId));
+        return convertToDTO(register(name, address, university, description, categoryId));
     }
 
     @Override
     @Transactional
     public ClubDTO.Response updateClub(Long id, String name, String address, String university, String description, Long categoryId) {
-        return convertToDTO(this.update(id, name, address, university, description, categoryId));
+        return convertToDTO(update(id, name, address, university, description, categoryId));
     }
 
     @Override
     public ClubDTO.Response convertToDTO(Club club) {
+        checkArgument(ObjectUtils.isNotEmpty(club), "club 값은 필수입니다.");
         return ClubDTO.Response.from(club);
     }
 
@@ -56,11 +56,11 @@ public class ClubServiceImpl implements ClubService {
     @Override
     @Transactional
     public Club register(String name, String address, String university, String description, Long categoryId) {
-        requireNonNull(name, "name 입력값은 필수입니다.");
-        requireNonNull(address, "address 입력값은 필수입니다.");
-        requireNonNull(university, "university 입력값은 필수입니다.");
-        requireNonNull(description, "description 입력값은 필수입니다.");
-        requireNonNull(categoryId, "categoryId 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(address), "address 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(description), "description 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(categoryId), "categoryId 입력값은 필수입니다.");
 
         if (existed(name, university)) {
             throw new AlreadyExistsException("이미 존재하는 클럽입니다");
@@ -81,7 +81,7 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public Club getClub(Long id) {
-        requireNonNull(id, "id 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(id), "id 입력값은 필수입니다.");
 
         return clubRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 클럽입니다."));
@@ -89,8 +89,8 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public Club getClub(String name, String university) {
-        requireNonNull(name, "name 입력값은 필수입니다.");
-        requireNonNull(university, "university 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
 
         return clubRepository.findByNameAndUniversity(name, university)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 클럽입니다."));
@@ -98,23 +98,23 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public List<Club> getClubs(String university, Pageable pageable) {
-        requireNonNull(university, "university 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
 
         return clubRepository.findAllByUniversity(university, pageable);
     }
 
     @Override
     public List<Club> getClubs(String name, String university, Pageable pageable) {
-        requireNonNull(name, "name 입력값은 필수입니다.");
-        requireNonNull(university, "university 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
 
         return clubRepository.findAllByNameAndUniversity(name, university, pageable);
     }
 
     @Override
     public List<Club> getClubs(List<Long> categories, String university, Pageable pageable) {
-        requireNonNull(categories, "categories 입력값은 필수입니다.");
-        requireNonNull(university, "university 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(categories), "categories 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
 
         List<Category> clubCategories = categoryService.getCategoriesById(categories);
 
@@ -123,9 +123,9 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public List<Club> getClubs(List<Long> categories, String university, String name, Pageable pageable) {
-        requireNonNull(categories, "categories 입력값은 필수입니다.");
-        requireNonNull(university, "university 입력값은 필수입니다.");
-        requireNonNull(name, "name 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(categories), "categories 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
 
         List<Category> clubCategories = categoryService.getCategoriesById(categories);
 
@@ -135,12 +135,12 @@ public class ClubServiceImpl implements ClubService {
     @Override
     @Transactional
     public Club update(Long id, String name, String address, String university, String description, Long categoryId) {
-        requireNonNull(id, "id 입력값은 필수입니다.");
-        requireNonNull(name, "name 입력값은 필수입니다.");
-        requireNonNull(address, "address 입력값은 필수입니다.");
-        requireNonNull(university, "university 입력값은 필수입니다.");
-        requireNonNull(description, "description 입력값은 필수입니다.");
-        requireNonNull(categoryId, "categoryId 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(id), "id 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(address), "address 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(description), "description 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(categoryId), "categoryId 입력값은 필수입니다.");
 
         Club updatedClub = clubRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 클럽입니다."));
@@ -169,6 +169,9 @@ public class ClubServiceImpl implements ClubService {
     @Override
     @Transactional
     public void updateImage(Long id, String imageUrl) {
+        checkArgument(ObjectUtils.isNotEmpty(id), "id 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(imageUrl), "imageUrl 입력값은 필수입니다.");
+
         Club updatedClub = getClub(id);
         updatedClub.updateImage(imageUrl);
     }
@@ -176,7 +179,7 @@ public class ClubServiceImpl implements ClubService {
     @Override
     @Transactional
     public void delete(Long id) {
-        requireNonNull(id, "id 입력값은 필수입니다.");
+        checkArgument(ObjectUtils.isNotEmpty(id), "id 입력값은 필수입니다.");
 
         Club deleteClub = clubRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("삭제하려는 id값이 존재하지 않습니다."));
@@ -186,8 +189,8 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public boolean existed(String name, String university) {
-        requireNonNull(name, "name 입력값은 필수입니다.");
-        requireNonNull(university, "university 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
+        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
 
         return clubRepository.existsByNameAndUniversity(name, university);
     }


### PR DESCRIPTION
## 작업 내용

- `Category`, `Club`(Club, ClubJoinState) Service 유효성 체크 로직 전부 반영
- `Category`, `Club`(Club, ClubJoinState) Service 유효성 체크 코드 변경
  - requireNonNull => checkArgument
  - 교체이유: NPE 대신 ExceptionHandler에서 잡고있는 `IllegalArgumentException`을 반환하기 위해
- 서비스 코드 내 불필요한 `this` 키워드 제거
- 불필요한 코드 static import 적용 