### PR TITLE
마스터/운영진/회원 판단 API 추가

### DIFF
--- a/src/main/java/com/example/club_project/controller/club/ClubJoinStateDTO.java
+++ b/src/main/java/com/example/club_project/controller/club/ClubJoinStateDTO.java
@@ -1,5 +1,6 @@
 package com.example.club_project.controller.club;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,5 +21,11 @@ public class ClubJoinStateDTO {
         private String profileUrl;
         private Long clubId;
         private Integer joinStateCode;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class JoinStateResponse {
+        private boolean result;
     }
 }

--- a/src/main/java/com/example/club_project/controller/club/ClubWithUserApiController.java
+++ b/src/main/java/com/example/club_project/controller/club/ClubWithUserApiController.java
@@ -186,4 +186,55 @@ public class ClubWithUserApiController {
 
         throw new ForbiddenException("권한이 없습니다.");
     }
+
+    /**
+     * 동아리 마스터인지
+     *
+     * GET api/clubs/is-master?clubId={clubId}
+     *
+     * master: true
+     * manager: false
+     * member: false
+     */
+    @GetMapping("/is-master")
+    public ClubJoinStateDTO.JoinStateResponse isClubMaster(@AuthenticationPrincipal AuthUserDTO authUser,
+                                                           @RequestParam("clubId") Long clubId) {
+
+        boolean result = clubJoinStateService.isClubMaster(authUser.getId(), clubId);
+        return new ClubJoinStateDTO.JoinStateResponse(result);
+    }
+
+    /**
+     * 동아리 운영진인지
+     *
+     * GET api/clubs/is-manager?clubId={clubId}
+     *
+     * master: true
+     * manager: true
+     * member: false
+     */
+    @GetMapping("/is-manager")
+    public ClubJoinStateDTO.JoinStateResponse isClubManager(@AuthenticationPrincipal AuthUserDTO authUser,
+                                                            @RequestParam("clubId") Long clubId) {
+
+        boolean result = clubJoinStateService.hasManagerRole(authUser.getId(), clubId);
+        return new ClubJoinStateDTO.JoinStateResponse(result);
+    }
+
+    /**
+     * 동아리 회원인지
+     *
+     * GET api/clubs/is-member?clubId={clubId}
+     *
+     * master: true
+     * manager: true
+     * member: true
+     */
+    @GetMapping("/is-member")
+    public ClubJoinStateDTO.JoinStateResponse isClubMember(@AuthenticationPrincipal AuthUserDTO authUser,
+                                                           @RequestParam("clubId") Long clubId) {
+
+        boolean result = clubJoinStateService.hasMemberRole(authUser.getId(), clubId);
+        return new ClubJoinStateDTO.JoinStateResponse(result);
+    }
 }


### PR DESCRIPTION
## 작업내용: API 3개 추가

- [현재 로그인한 사용자가 동아리 마스터인지 확인](https://github.com/chasw0326/club/wiki/API%EB%AC%B8%EC%84%9C#3-15-%EB%8F%99%EC%95%84%EB%A6%AC-%EB%A7%88%EC%8A%A4%ED%84%B0%EC%9D%B8%EC%A7%80-%ED%99%95%EC%9D%B8)
- [현재 로그인한 사용자가 동아리 운영진인지 확인](https://github.com/chasw0326/club/wiki/API%EB%AC%B8%EC%84%9C#3-16-%EB%8F%99%EC%95%84%EB%A6%AC-%EC%9A%B4%EC%98%81%EC%A7%84%EC%9D%B8%EC%A7%80-%ED%99%95%EC%9D%B8)
- [현재 로그인한 사용자가 동아리 일반 회원인지 확인](https://github.com/chasw0326/club/wiki/API%EB%AC%B8%EC%84%9C#3-17-%EB%8F%99%EC%95%84%EB%A6%AC-%ED%9A%8C%EC%9B%90%EC%9D%B8%EC%A7%80-%ED%99%95%EC%9D%B8)
