### PR TITLE
add: 이미지 첨부파일 처리를 위한 AttachedFile 클래스 추가

### DIFF
--- a/src/main/java/com/example/club_project/controller/club/ClubApiController.java
+++ b/src/main/java/com/example/club_project/controller/club/ClubApiController.java
@@ -1,5 +1,6 @@
 package com.example.club_project.controller.club;
 
+import com.example.club_project.controller.common.AttachedFile;
 import com.example.club_project.exception.custom.ForbiddenException;
 import com.example.club_project.exception.custom.UploadException;
 import com.example.club_project.security.dto.AuthUserDTO;
@@ -140,7 +141,10 @@ public class ClubApiController {
                                 @RequestPart MultipartFile clubImage) {
 
         if (clubJoinStateService.isClubMaster(authUser.getId(), clubId)) {
-            supplyAsync(() -> uploadUtil.upload(clubImage, "club-image"), taskExecutor)
+
+            AttachedFile attachedFile = AttachedFile.toAttachedFile(clubImage);
+
+            supplyAsync(() -> uploadUtil.upload(attachedFile, "club-image"), taskExecutor)
                     .thenAccept(clubImageUrl -> {
                         clubService.updateImage(clubId, clubImageUrl);
                     })

--- a/src/main/java/com/example/club_project/controller/common/AttachedFile.java
+++ b/src/main/java/com/example/club_project/controller/common/AttachedFile.java
@@ -1,0 +1,48 @@
+package com.example.club_project.controller.common;
+
+import com.example.club_project.exception.custom.UploadException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+@Getter
+@RequiredArgsConstructor
+public class AttachedFile {
+
+    private final String originalFileName;
+
+    private final String contentType;
+
+    private final byte[] bytes;
+
+    public static AttachedFile toAttachedFile(MultipartFile uploadFile) {
+        try {
+            if (isImageFile(uploadFile)) {
+                return new AttachedFile(uploadFile.getOriginalFilename(), uploadFile.getContentType(), uploadFile.getBytes());
+            }
+
+            throw new UploadException("이미지 파일 형식만 업로드 할 수 있습니다.");
+
+        } catch (IOException ignored) {
+            throw new UploadException("일시적인 에러가 발생했습니다. 반복적으로 에러 발생 시 관리자에게 문의해주세요.");
+        }
+    }
+
+    private static boolean isImageFile(MultipartFile uploadFile) {
+        if (ObjectUtils.isNotEmpty(uploadFile)
+                && uploadFile.getSize() > 0
+                && StringUtils.isNotEmpty(uploadFile.getOriginalFilename())) {
+
+            String contentType = uploadFile.getContentType();
+            return isNotEmpty(contentType) && contentType.toLowerCase().startsWith("image");
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/club_project/controller/user/UserApiController.java
+++ b/src/main/java/com/example/club_project/controller/user/UserApiController.java
@@ -2,6 +2,7 @@
 package com.example.club_project.controller.user;
 
 import com.example.club_project.controller.comment.CommentDTO;
+import com.example.club_project.controller.common.AttachedFile;
 import com.example.club_project.controller.post.PostDTO;
 import com.example.club_project.exception.custom.UploadException;
 import com.example.club_project.security.dto.AuthUserDTO;
@@ -94,10 +95,12 @@ public class UserApiController {
     }
 
     @PutMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public void updateClubImage(@AuthenticationPrincipal AuthUserDTO authUser,
+    public void updateProfileImage(@AuthenticationPrincipal AuthUserDTO authUser,
                                 @RequestPart MultipartFile profileImage) {
 
-        supplyAsync(() -> uploadUtil.upload(profileImage, "user-image"), taskExecutor)
+        AttachedFile attachedFile = AttachedFile.toAttachedFile(profileImage);
+
+        supplyAsync(() -> uploadUtil.upload(attachedFile, "user-image"), taskExecutor)
                 .thenAccept(userImageUrl -> {
                     userService.updateProfileImage(authUser.getId(), userImageUrl);
                 })

--- a/src/main/java/com/example/club_project/util/upload/S3UploadUtil.java
+++ b/src/main/java/com/example/club_project/util/upload/S3UploadUtil.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.club_project.config.AwsConfigure;
+import com.example.club_project.controller.common.AttachedFile;
 import com.example.club_project.exception.custom.InvalidArgsException;
 import com.example.club_project.exception.custom.UploadException;
 import lombok.RequiredArgsConstructor;
@@ -33,33 +34,12 @@ public class S3UploadUtil implements UploadUtil {
     private final AwsConfigure awsConfigure;
 
     @Override
-    public String upload(MultipartFile uploadFile, String uploadPath) {
+    public String upload(AttachedFile uploadFile, String uploadPath) {
+        byte[] bytes = uploadFile.getBytes();
+        String filename = uploadFile.getOriginalFileName();
+        String contentType = uploadFile.getContentType();
 
-        if (!isImageFile(uploadFile)) {
-            throw new InvalidArgsException("Only image file format is allowed.");
-        }
-
-        try {
-            byte[] bytes = uploadFile.getBytes();
-            String filename = uploadFile.getOriginalFilename();
-            String contentType = uploadFile.getContentType();
-
-            return upload(bytes, uploadPath, filename, contentType);
-        } catch (IOException ignored) {
-            throw new UploadException(String.format("ignored IOException occur with %s", uploadFile.getOriginalFilename()));
-        }
-    }
-
-    private boolean isImageFile(MultipartFile uploadFile) {
-        if (ObjectUtils.isNotEmpty(uploadFile)
-            && uploadFile.getSize() > 0
-            && StringUtils.isNotEmpty(uploadFile.getOriginalFilename())) {
-
-            String contentType = uploadFile.getContentType();
-            return isNotEmpty(contentType) && contentType.toLowerCase().startsWith("image");
-        }
-
-        return false;
+        return upload(bytes, uploadPath, filename, contentType);
     }
 
     private String upload(byte[] bytes, String uploadPath, String filename, String contentType) {

--- a/src/main/java/com/example/club_project/util/upload/UploadUtil.java
+++ b/src/main/java/com/example/club_project/util/upload/UploadUtil.java
@@ -1,6 +1,6 @@
 package com.example.club_project.util.upload;
 
-import org.springframework.web.multipart.MultipartFile;
+import com.example.club_project.controller.common.AttachedFile;
 
 
 public interface UploadUtil {
@@ -10,5 +10,5 @@ public interface UploadUtil {
      * @param uploadPath 저장할 폴더경로
      * @return saveName (이 Url를 DB에 저장)
      */
-    String upload(MultipartFile uploadFile, String uploadPath);
+    String upload(AttachedFile uploadFile, String uploadPath);
 }


### PR DESCRIPTION
## 작업내용

- controller/common/AttachedFile 클래스 추가
  - 추가목적: 파일형식 유효성 체크 로직을 분리해서 ExceptionHandler를 통해 400 응답을 내려주기 위함
  - 기존 방식에서는 모든 과정이 별도 쓰레드를 통해 진행되므로 ExceptionHandler를 통해 예외 응답 불가능

## AttachedFile 클래스 역할

- `MultipartFile` 클래스를 내부적으로 업로드 로직할 때 사용할 파일형식으로 형변환하는 DTO
- 특정 도메인에 국한되지 않고 공통적으로 사용될 기능(유저, 동아리 등)이므로 뒤에 DTO를 붙이지 않음 

## 바뀐 내용

- 이미지 파일 형식 외의 파일을 업로드 하는 경우 400응답을 내려줌
- 이외에 단순히 업로드 된 파일을 읽는데 실패한 경우 (IOException) 400응답을 내려줌
- [사용자 이미지 수정](https://github.com/chasw0326/club/wiki/API%EB%AC%B8%EC%84%9C#1-11-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%88%98%EC%A0%95)
- [동아리 이미지 수정](https://github.com/chasw0326/club/wiki/API%EB%AC%B8%EC%84%9C#3-5-%EB%8F%99%EC%95%84%EB%A6%AC-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%88%98%EC%A0%95)