### PR TITLE
add: 파일 업로드 max-size 1MB -> 10MB로 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   profiles:
     active: local
+  servlet:
+    multipart:
+      max-file-size: 10MB
 
 # 쓰레드풀 설정
 async:


### PR DESCRIPTION
파일 업로드 사이즈 1MB(default option)에서 10MB로 수정했습니다.

build 디렉토리 지우신 후에 다시 `gradlew build` 해주시고 서버 띄워주셔야 적용될 겁니다~