### PR TITLE
add: Querydsl 설정 적용 및 쿼리 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ dependencies {
     testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: '5.5.3'
     testCompileOnly 'org.projectlombok:lombok:1.18.12'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
+
+    // querydsl 관련 추가
+    implementation "com.querydsl:querydsl-core" // querydsl
+    implementation "com.querydsl:querydsl-jpa" // querydsl
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"  // querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'   // java.lang.NoClassDefFoundError(javax.annotation.Entity) 발생 대응
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api' // java.lang.NoClassDefFoundError (javax.annotation.Generated) 발생 대응
 }
 
 test {

--- a/src/main/java/com/example/club_project/config/QuerydslConfigure.java
+++ b/src/main/java/com/example/club_project/config/QuerydslConfigure.java
@@ -1,0 +1,20 @@
+package com.example.club_project.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfigure {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/club_project/controller/club/ClubApiController.java
+++ b/src/main/java/com/example/club_project/controller/club/ClubApiController.java
@@ -9,10 +9,8 @@ import com.example.club_project.service.clubjoinstate.ClubJoinStateService;
 import com.example.club_project.util.upload.UploadUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -50,30 +48,14 @@ public class ClubApiController {
      * 검색조건4: 카테고리 + 동아리 이름
      */
     @GetMapping
-    public List<ClubDTO> searchClubs(@AuthenticationPrincipal AuthUserDTO authUser,
-                                                              ClubDTO.SearchOption searchOption,
-                                     @PageableDefault(
-                                            size = 20,
-                                            sort = "id",
-                                            direction = Sort.Direction.DESC) Pageable pageable) {
+    public List<ClubDTO.SimpleResponse> searchClubs(@AuthenticationPrincipal AuthUserDTO authUser,
+                                                                ClubDTO.SearchOption searchOption,
+                                                    @PageableDefault(size = 5) Pageable pageable) {
 
-        if (ObjectUtils.isEmpty(searchOption.getName()) && ObjectUtils.isEmpty(searchOption.getCategories())) {
-            return clubJoinStateService.getClubDtos(authUser.getUniversity(), pageable);
-        } else if (ObjectUtils.isEmpty(searchOption.getCategories())) {
-            return clubJoinStateService.getClubDtos(searchOption.getName(),
-                                                    authUser.getUniversity(),
-                                                    pageable);
-
-        } else if (ObjectUtils.isEmpty(searchOption.getName())) {
-            return clubJoinStateService.getClubDtos(searchOption.getCategories(),
-                                                    authUser.getUniversity(),
-                                                    pageable);
-        } else {
-            return clubJoinStateService.getClubDtos(searchOption.getCategories(),
-                                                    authUser.getUniversity(),
-                                                    searchOption.getName(),
-                                                    pageable);
-        }
+        return clubJoinStateService.getClubDtos(searchOption.getCategories(),
+                                                authUser.getUniversity(),
+                                                searchOption.getName(),
+                                                pageable);
     }
 
     /**

--- a/src/main/java/com/example/club_project/controller/club/ClubDTO.java
+++ b/src/main/java/com/example/club_project/controller/club/ClubDTO.java
@@ -16,18 +16,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.*;
 
-@AllArgsConstructor
-@Getter
 public class ClubDTO {
-
-    private Long id;
-    private String name;
-    private String address;
-    private String university;
-    private String description;
-    private String imageUrl;
-    private Long category;
-    private long clubMembers;
 
     /**
      * GET
@@ -134,6 +123,19 @@ public class ClubDTO {
                             .name(member.getUser().getName())
                             .build();
         }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class SimpleResponse {
+        private Long id;
+        private String name;
+        private String address;
+        private String university;
+        private String description;
+        private String imageUrl;
+        private Long category;
+        private long clubMembers;
     }
 
     @Builder

--- a/src/main/java/com/example/club_project/repository/ClubJoinStateRepository.java
+++ b/src/main/java/com/example/club_project/repository/ClubJoinStateRepository.java
@@ -1,6 +1,5 @@
 package com.example.club_project.repository;
 
-import com.example.club_project.controller.club.ClubDTO;
 import com.example.club_project.domain.ClubJoinState;
 import com.example.club_project.domain.JoinState;
 import org.springframework.data.domain.Pageable;
@@ -126,94 +125,4 @@ public interface ClubJoinStateRepository extends JpaRepository<ClubJoinState, Lo
     List<ClubJoinState> findAllByUserContainingJoinState(@Param("userId") Long userId,
                                                          @Param("joinState") JoinState joinState,
                                                          Pageable pageable);
-
-    /**
-     * For ClubWithMemberCount
-     */
-    @Query("select new com.example.club_project.controller.club.ClubDTO(" +
-                "club.id, " +
-                "club.name, " +
-                "club.address, " +
-                "club.university, " +
-                "club.description, " +
-                "club.imageUrl, " +
-                "category.id, " +
-                "count(user)" +
-            ") " +
-            "from ClubJoinState c " +
-                "join c.user user " +
-                "join c.club club " +
-                "join club.category category " +
-            "where club.university = :university " +
-                "and c.isUsed = true " +
-            "group by club")
-    List<ClubDTO> findAllByUniversity(@Param("university") String university, Pageable pageable);
-
-    @Query("select new com.example.club_project.controller.club.ClubDTO(" +
-                "club.id, " +
-                "club.name, " +
-                "club.address, " +
-                "club.university, " +
-                "club.description, " +
-                "club.imageUrl, " +
-                "category.id, " +
-                "count(user)" +
-            ") " +
-            "from ClubJoinState c " +
-                "join c.user user " +
-                "join c.club club " +
-                "join club.category category " +
-            "where club.name like %:name% " +
-                "and club.university = :university " +
-                "and c.isUsed = true " +
-            "group by club")
-    List<ClubDTO> findAllByNameAndUniversity(@Param("name") String name,
-                                             @Param("university") String university,
-                                             Pageable pageable);
-
-    @Query("select new com.example.club_project.controller.club.ClubDTO(" +
-                "club.id, " +
-                "club.name, " +
-                "club.address, " +
-                "club.university, " +
-                "club.description, " +
-                "club.imageUrl, " +
-                "category.id, " +
-                "count(user)" +
-            ") " +
-            "from ClubJoinState c " +
-                "join c.user user " +
-                "join c.club club " +
-                "join club.category category " +
-            "where club.university = :university " +
-                "and category.id in :categories " +
-                "and c.isUsed = true " +
-            "group by club")
-    List<ClubDTO> findAll(@Param("categories") List<Long> categories,
-                          @Param("university") String university,
-                          Pageable pageable);
-
-    @Query("select new com.example.club_project.controller.club.ClubDTO(" +
-                "club.id, " +
-                "club.name, " +
-                "club.address, " +
-                "club.university, " +
-                "club.description, " +
-                "club.imageUrl, " +
-                "category.id, " +
-                "count(user)" +
-            ") " +
-            "from ClubJoinState c " +
-                "join c.user user " +
-                "join c.club club " +
-                "join club.category category " +
-            "where club.name like %:name% " +
-                "and club.university = :university " +
-                "and category.id in :categories " +
-                "and c.isUsed = true " +
-            "group by club")
-    List<ClubDTO> findAll(@Param("categories") List<Long> categories,
-                          @Param("name") String name,
-                          @Param("university") String university,
-                          Pageable pageable);
 }

--- a/src/main/java/com/example/club_project/repository/query/ClubQueryRepository.java
+++ b/src/main/java/com/example/club_project/repository/query/ClubQueryRepository.java
@@ -1,0 +1,81 @@
+package com.example.club_project.repository.query;
+
+import com.example.club_project.controller.club.ClubDTO;
+import com.example.club_project.domain.JoinState;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.example.club_project.domain.QCategory.category;
+import static com.example.club_project.domain.QClub.club;
+import static com.example.club_project.domain.QClubJoinState.clubJoinState;
+
+/**
+ * Entity가 아닌 API 전용 DTO 객체를 select 하기 위한 Repository
+ */
+@RequiredArgsConstructor
+@Component
+public class ClubQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<ClubDTO.SimpleResponse> findAll(List<Long> categories, String university, String name, Pageable pageable) {
+
+        return queryFactory
+                .select(
+                    Projections.constructor(ClubDTO.SimpleResponse.class,
+                        club.id,
+                        club.name,
+                        club.address,
+                        club.university,
+                        club.description,
+                        club.imageUrl,
+                        club.category.id,
+                        clubJoinState.id.count()
+                    )
+                )
+                .from(club)
+                    .join(club.category, category)
+                    .leftJoin(clubJoinState).on(club.id.eq(clubJoinState.club.id))
+                                            .on(clubJoinState.joinState.ne(JoinState.NOT_JOINED))
+                                            .on(clubJoinState.isUsed.eq(true))
+                .where(
+                    universityEq(university),
+                    categoriesEq(categories),
+                    nameContains(name)
+                )
+                .groupBy(club.id, club.name)
+                .orderBy(club.id.desc())
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+    }
+
+    private BooleanExpression universityEq(String university) {
+        if (StringUtils.isBlank(university)) {
+            return null;
+        }
+        return club.university.eq(university);
+    }
+
+    private BooleanExpression categoriesEq(List<Long> categories) {
+        if (ObjectUtils.isEmpty(categories)) {
+            return null;
+        }
+        return club.category.id.in(categories);
+    }
+
+    private BooleanExpression nameContains(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        return club.name.contains(name);
+    }
+}

--- a/src/main/java/com/example/club_project/service/clubjoinstate/ClubJoinStateService.java
+++ b/src/main/java/com/example/club_project/service/clubjoinstate/ClubJoinStateService.java
@@ -13,13 +13,7 @@ public interface ClubJoinStateService {
     /**
      * DTO Region (for other controllers)
      */
-    List<ClubDTO> getClubDtos(String university, Pageable pageable);
-
-    List<ClubDTO> getClubDtos(String name, String university, Pageable pageable);
-
-    List<ClubDTO> getClubDtos(List<Long> categories, String university, Pageable pageable);
-
-    List<ClubDTO> getClubDtos(List<Long> categories, String university, String name, Pageable pageable);
+    List<ClubDTO.SimpleResponse> getClubDtos(List<Long> categories, String university, String name, Pageable pageable);
 
     ClubDTO.DetailResponse getClubDetailDto(Long clubId);
 

--- a/src/main/java/com/example/club_project/service/clubjoinstate/ClubJoinStateServiceImpl.java
+++ b/src/main/java/com/example/club_project/service/clubjoinstate/ClubJoinStateServiceImpl.java
@@ -9,12 +9,12 @@ import com.example.club_project.domain.User;
 import com.example.club_project.exception.custom.AlreadyExistsException;
 import com.example.club_project.exception.custom.NotFoundException;
 import com.example.club_project.repository.ClubJoinStateRepository;
+import com.example.club_project.repository.query.ClubQueryRepository;
 import com.example.club_project.service.club.ClubService;
 import com.example.club_project.service.user.UserService;
 import com.example.club_project.util.ValidateUtil;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -35,6 +35,7 @@ public class ClubJoinStateServiceImpl implements ClubJoinStateService {
     private static final int MEMBER_SIZE = 10;
 
     private final ClubJoinStateRepository clubJoinStateRepository;
+    private final ClubQueryRepository clubQueryRepository;
     private final UserService userService;
     private final ClubService clubService;
     private final ValidateUtil validateUtil;
@@ -44,41 +45,8 @@ public class ClubJoinStateServiceImpl implements ClubJoinStateService {
      * for Controller
      */
     @Override
-    public List<ClubDTO> getClubDtos(String university, Pageable pageable) {
-        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
-
-        return clubJoinStateRepository.findAllByUniversity(university, getPageByClub(pageable));
-    }
-
-    @Override
-    public List<ClubDTO> getClubDtos(String name, String university, Pageable pageable) {
-        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
-        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
-
-        return clubJoinStateRepository.findAllByNameAndUniversity(name, university, getPageByClub(pageable));
-    }
-
-    @Override
-    public List<ClubDTO> getClubDtos(List<Long> categories, String university, Pageable pageable) {
-        checkArgument(ObjectUtils.isNotEmpty(categories), "categories 입력값은 필수입니다.");
-        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
-
-        return clubJoinStateRepository.findAll(categories, university, getPageByClub(pageable));
-    }
-
-    @Override
-    public List<ClubDTO> getClubDtos(List<Long> categories, String university, String name, Pageable pageable) {
-        checkArgument(ObjectUtils.isNotEmpty(categories), "categories 입력값은 필수입니다.");
-        checkArgument(StringUtils.isNotEmpty(university), "university 입력값은 필수입니다.");
-        checkArgument(StringUtils.isNotEmpty(name), "name 입력값은 필수입니다.");
-
-        return clubJoinStateRepository.findAll(categories, name, university, getPageByClub(pageable));
-    }
-
-    private Pageable getPageByClub(Pageable defaultPageable) {
-        return PageRequest.of(defaultPageable.getPageNumber(),
-                              defaultPageable.getPageSize(),
-                              Sort.by(DESC, "club"));
+    public List<ClubDTO.SimpleResponse> getClubDtos(List<Long> categories, String university, String name, Pageable pageable) {
+        return clubQueryRepository.findAll(categories, university, name, pageable);
     }
 
     @Override

--- a/src/test/java/com/example/club_project/service/clubjoinstate/ClubJoinStateServiceTest.java
+++ b/src/test/java/com/example/club_project/service/clubjoinstate/ClubJoinStateServiceTest.java
@@ -178,12 +178,12 @@ class ClubJoinStateServiceTest {
 
         //when
         String university = "test";
-        List<ClubDTO> clubDtos = clubJoinStateService.getClubDtos(university, testPageRequest);
+        List<ClubDTO.SimpleResponse> clubDtos = clubJoinStateService.getClubDtos(null, university, null, testPageRequest);
 
         //then
         assertThat(clubDtos.size()).isEqualTo(5);
 
-        for (ClubDTO clubDto : clubDtos) {
+        for (ClubDTO.SimpleResponse clubDto : clubDtos) {
             assertThat(clubDto.getClubMembers()).isNotEqualTo(0);
         }
     }
@@ -207,12 +207,12 @@ class ClubJoinStateServiceTest {
         //when
         String searchKeyword = "club";
         String university = "test";
-        List<ClubDTO> clubDtos = clubJoinStateService.getClubDtos(searchKeyword, university, testPageRequest);
+        List<ClubDTO.SimpleResponse> clubDtos = clubJoinStateService.getClubDtos(null, university, searchKeyword, testPageRequest);
 
         //then
         assertThat(clubDtos.size()).isEqualTo(5);
 
-        for (ClubDTO clubDto : clubDtos) {
+        for (ClubDTO.SimpleResponse clubDto : clubDtos) {
             assertThat(clubDto.getClubMembers()).isNotEqualTo(0);
         }
     }
@@ -236,12 +236,12 @@ class ClubJoinStateServiceTest {
         //when
         List<Long> searchCategories = new ArrayList<>(Arrays.asList(mockCategory1.getId(), mockCategory2.getId(), mockCategory3.getId()));
         String university = "test";
-        List<ClubDTO> clubDtos = clubJoinStateService.getClubDtos(searchCategories, university, testPageRequest);
+        List<ClubDTO.SimpleResponse> clubDtos = clubJoinStateService.getClubDtos(searchCategories, university, null, testPageRequest);
 
         //then
         assertThat(clubDtos.size()).isEqualTo(3);
 
-        for (ClubDTO clubDto : clubDtos) {
+        for (ClubDTO.SimpleResponse clubDto : clubDtos) {
             assertThat(clubDto.getClubMembers()).isNotEqualTo(0);
         }
     }
@@ -266,12 +266,12 @@ class ClubJoinStateServiceTest {
         List<Long> searchCategories = new ArrayList<>(Arrays.asList(mockCategory1.getId(), mockCategory2.getId()));
         String searchKeyword = "club";
         String university = "test";
-        List<ClubDTO> clubDtos = clubJoinStateService.getClubDtos(searchCategories, university, searchKeyword, testPageRequest);
+        List<ClubDTO.SimpleResponse> clubDtos = clubJoinStateService.getClubDtos(searchCategories, university, searchKeyword, testPageRequest);
 
         //then
         assertThat(clubDtos.size()).isEqualTo(2);
 
-        for (ClubDTO clubDto : clubDtos) {
+        for (ClubDTO.SimpleResponse clubDto : clubDtos) {
             assertThat(clubDto.getClubMembers()).isNotEqualTo(0);
         }
     }


### PR DESCRIPTION
## 작업 내용

1. Querydsl dependency 적용
1. Querydsl 설정 클래스 추가
1. 메인 페이지 Club 조회 페이징 기본 사이즈 `20 => 5로 변경`
1. ClubDTO => ClubDTO.SimpleResponse로 변경
    - 이유: 기존에 존재하던 ClubDTO.DetailResponse와 반대되는 의미로 사용
1. ClubDTO.SimpleResponse 조회 전용 ClubQueryRepository 추가