### PR TITLE
fix: clubJoinState 조회 조건 변경

### DIFF
--- a/src/main/java/com/example/club_project/repository/ClubJoinStateRepository.java
+++ b/src/main/java/com/example/club_project/repository/ClubJoinStateRepository.java
@@ -72,7 +72,8 @@ public interface ClubJoinStateRepository extends JpaRepository<ClubJoinState, Lo
                         "join fetch c.user " +
                         "join fetch c.club club " +
                         "join fetch club.category " +
-                    "where c.club.id = :clubId")
+                    "where c.club.id = :clubId " +
+                        "and c.isUsed = true")
     List<ClubJoinState> findAllByClub(@Param("clubId") Long clubId, Pageable pageable);
 
     @Query("select c from ClubJoinState c " +
@@ -80,7 +81,8 @@ public interface ClubJoinStateRepository extends JpaRepository<ClubJoinState, Lo
                         "join fetch c.club club " +
                         "join fetch club.category " +
                     "where c.club.id = :clubId " +
-                        "and c.joinState = :joinState")
+                        "and c.joinState = :joinState " +
+                        "and c.isUsed = true")
     List<ClubJoinState> findAllByClub(@Param("clubId") Long clubId,
                                       @Param("joinState") JoinState joinState,
                                       Pageable pageable);
@@ -90,7 +92,19 @@ public interface ClubJoinStateRepository extends JpaRepository<ClubJoinState, Lo
                         "join fetch c.club club " +
                         "join fetch club.category " +
                     "where c.club.id = :clubId " +
-                        "and c.joinState <= :joinState")
+                        "and c.joinState <> :joinState " +
+                        "and c.isUsed = true")
+    List<ClubJoinState> findAllByClubExceptJoinState(@Param("clubId") Long clubId,
+                                                     @Param("joinState") JoinState joinState,
+                                                     Pageable pageable);
+
+    @Query("select c from ClubJoinState c " +
+                        "join fetch c.user " +
+                        "join fetch c.club club " +
+                        "join fetch club.category " +
+                    "where c.club.id = :clubId " +
+                        "and c.joinState <= :joinState " +
+                        "and c.isUsed = true")
     List<ClubJoinState> findAllByClubContainingJoinState(@Param("clubId") Long clubId,
                                                          @Param("joinState") JoinState joinState,
                                                          Pageable pageable);
@@ -103,7 +117,8 @@ public interface ClubJoinStateRepository extends JpaRepository<ClubJoinState, Lo
                         "join fetch c.user " +
                         "join fetch c.club club " +
                         "join fetch club.category " +
-                    "where c.user.id = :userId")
+                    "where c.user.id = :userId " +
+                        "and c.isUsed = true")
     List<ClubJoinState> findAllByUser(@Param("userId") Long userId, Pageable pageable);
 
     @Query("select c from ClubJoinState c " +
@@ -111,7 +126,8 @@ public interface ClubJoinStateRepository extends JpaRepository<ClubJoinState, Lo
                         "join fetch c.club club " +
                         "join fetch club.category " +
                     "where c.user.id = :userId " +
-                        "and c.joinState = :joinState")
+                        "and c.joinState = :joinState " +
+                        "and c.isUsed = true")
     List<ClubJoinState> findAllByUser(@Param("userId") Long userId,
                                       @Param("joinState") JoinState joinState,
                                       Pageable pageable);
@@ -121,7 +137,19 @@ public interface ClubJoinStateRepository extends JpaRepository<ClubJoinState, Lo
                         "join fetch c.club club " +
                         "join fetch club.category " +
                     "where c.user.id = :userId " +
-                        "and c.joinState <= :joinState")
+                        "and c.joinState <> :joinState " +
+                        "and c.isUsed = true")
+    List<ClubJoinState> findAllByUserExceptJoinState(@Param("userId") Long userId,
+                                                     @Param("joinState") JoinState joinState,
+                                                     Pageable pageable);
+
+    @Query("select c from ClubJoinState c " +
+                        "join fetch c.user " +
+                        "join fetch c.club club " +
+                        "join fetch club.category " +
+                    "where c.user.id = :userId " +
+                        "and c.joinState <= :joinState " +
+                        "and c.isUsed = true")
     List<ClubJoinState> findAllByUserContainingJoinState(@Param("userId") Long userId,
                                                          @Param("joinState") JoinState joinState,
                                                          Pageable pageable);


### PR DESCRIPTION
## 작업내용

### clubJoinState 복수 건 조회 조건 변경

- 바뀌기 전의 조회 조건
  - `isUsed`의 `true/false`에 관계 없이 전부 쿼리로 조회 후 application에서 filter 조건으로 `isUsed == true`인 row만 사용
- 바뀐 후의 조회 조건
  - 복수 건 조회 시 `isUsed` 필드 값이 true인 row만 가져오도록 수정

### 변경 이유

- 페이징 옵션 적용 시 `isUsed == false`인 row도 페이징 옵션에 같이 조회됨. 그래서 페이징 조건을 만족하는 `isUsed == true`인 row가 제대로 검색되지 않는 현상 발생
- 그래서 쿼리 자체에서부터 올바른 조건에 대해 페이징을 걸도록 수정